### PR TITLE
Add minecraft update dispatch

### DIFF
--- a/.github/workflows/tick.yml
+++ b/.github/workflows/tick.yml
@@ -23,6 +23,12 @@ jobs:
     if: ${{ needs.check.outputs.id != '' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.SANDSTONE_PAT }}
+          repository: sandstone-mc/sandstone
+          event-type: minecraft-update
+
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2


### PR DESCRIPTION
Sandstone needs to run its generate script every time there's an update, and I figured it'd be better to do this than run my own tick.

If this is accepted I can supply you with a scoped PAT you can add to your repo secrets.